### PR TITLE
check WindowClient == null to reject payment request

### DIFF
--- a/bobpay/public/pay/sw-bobpay.js
+++ b/bobpay/public/pay/sw-bobpay.js
@@ -8,6 +8,10 @@ self.addEventListener('paymentrequest', function(e) {
   e.respondWith(payment_request_resolver.promise);
 
   e.openWindow("https://bobpay.xyz/pay")
+  .then(window_client => {
+    if(window_client == null)
+      payment_request_resolver.reject('failed to open window');
+  })
   .catch(function(err) {
     payment_request_resolver.reject(err);
   })


### PR DESCRIPTION
The spec has been changed to return null when trying to open a window out of the service worker origin.