### PR TITLE
Check WindowClient == null to reject payment request

### DIFF
--- a/bobpay/public/pay/sw-bobpay.js
+++ b/bobpay/public/pay/sw-bobpay.js
@@ -13,6 +13,10 @@ self.addEventListener('paymentrequest', function(e) {
     url += "/alipay.html";
 
   e.openWindow(url)
+    .then(window_client => {
+      if(window_client == null)
+        payment_request_resolver.reject('Failed to open window');
+    })
     .catch(function(err) {
       payment_request_resolver.reject(err);
     })


### PR DESCRIPTION
The spec has been changed to return null if the window is opened in a different origin