### PR TITLE
Create BobPay payment method

### DIFF
--- a/bobpay/app.js
+++ b/bobpay/app.js
@@ -7,7 +7,7 @@ let app = express();
 app.use(function(req, res, next) {
   res.status(200).links({
     'payment-method-manifest':
-        'https://rsolomakhin.github.io/bobpay/payment-manifest.json',
+        'https://bobpay.xyz/pay/payment-manifest.json',
     });
     return next();
 });

--- a/bobpay/public/index.html
+++ b/bobpay/public/index.html
@@ -66,7 +66,7 @@
                 sizes:"32x32",
                 type:"image/png"}
               ],
-              method: "https://emerald-eon.appspot.com/bobpay"
+              method: "https://bobpay.xyz/pay"
             }),
         registration.paymentManager.instruments.set(
             "new-card",

--- a/bobpay/public/pay/payment-manifest.json
+++ b/bobpay/public/pay/payment-manifest.json
@@ -1,0 +1,4 @@
+{
+  "default_applications": ["https://bobpay.xyz/pay/manifest.json"],
+  "supported_origins": ["https://bobpay.xyz", "https://webauthn.org", "https://webauthn.org:8443", "https://webauthn.org:8000", "https://webauthn05.noknoktest.com:8443", "https://gogerald.github.io", "https://upay.noknoktest.com", "https://rsolomakhin.github.io"]
+}


### PR DESCRIPTION
In order to enable JIT install of BobPay, create a new payment method of `https://bobpay.xyz/pay`.
- Change payment method identifier
- `https://bobpay.xyz/pay` to point to `https://bobpay.xyz/pay/payment-manifest.json`
- `https://bobpay.xyz/pay/payment-manifest.json` to include `https://bobpay.xyz/pay/manifest.json` as a default application.